### PR TITLE
Use defined exit codes so STATE_OK isn't used unintentionally

### DIFF
--- a/check_systemd_timer
+++ b/check_systemd_timer
@@ -48,7 +48,7 @@ diff=$(( $now_date-$last_execution_date ))
 
 if [ $diff -gt $critical ]; then
     echo "ERROR: service ${service}.service was executed $diff seconds ago."
-    exit $STATE_ERROR
+    exit $STATE_CRITICAL
 elif [ $diff -gt $warning ]; then
     echo "WARNING: service ${service}.service was executed $diff seconds ago."
     exit $STATE_WARNING
@@ -72,7 +72,7 @@ else
     stateError=$(echo $state_msg | grep "failed" | wc -l)
     if [ $state -ne 1 -o $stateError -ne 0 ]; then
         echo "ERROR: service ${service}.service was executed $diff seconds ago and exited with status $state_msg."
-        exit $STATE_ERROR
+        exit $STATE_CRITICAL
     fi
 
 fi


### PR DESCRIPTION
utils.sh[1] doesn't define a STATE_ERROR. Use STATE_CRITICAL instead.
Without this, the plugin call `exit` with no arguments, which uses the
exit code of the previous command. Since the previous command is `echo`
in both cases, the script will exit with the 0 code, which is STATE_OK.
That means nagios will consider it successful when the service has
failed.

1. https://github.com/nagios-plugins/nagios-plugins/blob/master/plugins-scripts/utils.sh.in